### PR TITLE
Fix: Resolve accuracy output type mismatch causing ValueError in qwen25_vllm_osworld_g_jedi.py

### DIFF
--- a/evaluation/qwen25_vllm_osworld_g_jedi.py
+++ b/evaluation/qwen25_vllm_osworld_g_jedi.py
@@ -417,9 +417,10 @@ class BenchmarkRunner:
 
         accuracy = correct / total
         for group in accuracy_dict_group:
-            accuracy_dict_group[group][
-                "accuracy"
-            ] = f"{(accuracy_dict_group[group]['correct'] / accuracy_dict_group[group]['total'])*100:.2f}%"
+            accuracy_dict_group[group]["accuracy"] = (
+                accuracy_dict_group[group]["correct"]
+                / accuracy_dict_group[group]["total"]
+            )
         return {
             "total": total,
             "correct": correct,


### PR DESCRIPTION
## Problem

The `qwen25_vllm_osworld_g_jedi.py` evaluation script contains a type mismatch bug that causes a `ValueError` when printing accuracy results.

### Bug Details

**Line 422** stores accuracy as a formatted string:
```python
accuracy_dict_group[group]["accuracy"] = f"{(correct/total)*100:.2f}%"

# Result: "85.00%" (string)
```

**Line 547** attempts to multiply this string by 100:

```python
print(f"  {group}: {stats['accuracy']*100:.2f}%")
# Attempts: "85.00%" * 100 → ValueError!
```

### Error Message

Line 547 attempts to multiply this string by 100:
```
print(f"  {group}: {stats['accuracy']*100:.2f}%")
# Attempts: "85.00%" * 100 → ValueError!e:
- **Pattern A** (aguvis.py, operator.py): Store as string `"85.00%"` → Print dict directly
- **Pattern B** (screenspot_v2.py, screenspot_pro.py): Store as float `0.85` → Format with `*100`
- **This file**: Store as string (Pattern A) + Format with `*100` (Pattern B) → **Incompatible!**
```

## Solution

Changed line 422 to store accuracy as a float instead of a string, making it consistent with the screenspot pattern used in line 547's output formatting.

### Changes

```python
# Before (Bug)
accuracy_dict_group[group]["accuracy"] = f"{(correct/total)*100:.2f}%"

# After (Fixed)
accuracy_dict_group[group]["accuracy"] = (
    accuracy_dict_group[group]["correct"]
    / accuracy_dict_group[group]["total"]
)
```

## Testing

Created reproduction tests that confirm:
1. ✅ Bug reproduced with original code (ValueError occurs)
2. ✅ Fix resolves the issue (correct output generated)
3. ✅ Output format remains as intended:

## ErrorMessage
```
ValueError: Unknown format code 'f' for object of type 'str'osworld_g_jedi.py`)
- **Lines changed**: 4 insertions(+), 3 deletions(-)
- **Breaking changes**: None
- **Backward compatibility**: Fully maintained (output format unchanged)
```

## Related Issues

```
This may be related to #13 (Can't reproduce the OSWorld-G results) as the evaluation script would crash when attempting to display results.
```

   