### PR TITLE
Fix missing image_size parameter in eval.py

### DIFF
--- a/evaluation/eval.py
+++ b/evaluation/eval.py
@@ -27,8 +27,11 @@ class GroundingEval:
                 data["size"],
                 data["boxes_coordinate"],
             )
+            image_size = [image.width, image.height]
 
-            success += self._eval(coordinate, boxes_type, boxes_size, boxes_coordinate)
+            success += self._eval(
+                coordinate, boxes_type, boxes_size, boxes_coordinate, image_size
+            )
 
         return success / total
 


### PR DESCRIPTION
The eval() method was calling _eval() with only 4 parameters (coordinate, boxes_type, boxes_size, boxes_coordinate) on line 31, but _eval() requires 5 parameters including image_size (line 35-41).

This caused a TypeError when the eval() method was called:
  TypeError: _eval() missing 1 required positional argument: 'image_size'

The image_size parameter is essential because _eval() uses it on line 67 to scale normalized coordinates (values between 0 and 1) to pixel coordinates.

This fix adds:
1. Line 30: Extract image_size from the PIL Image object
2. Line 32-34: Pass image_size as the 5th parameter to _eval()

This brings eval.py into consistency with all other evaluation scripts (qwen25_vllm_osworld_g_jedi.py, screenspot_v2, screenspot_pro, aguvis, operator) which all correctly pass image_size to _eval().

Note: This bug only affected the eval() method used for standalone testing (line 90-92). The _eval() method itself was always correct and is used properly by all production evaluation scripts.